### PR TITLE
chore: add lint npm script

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "tsc --noEmit && prettier --check . && eslint . --ext .ts,.tsx"
   },
   "browserslist": {
     "production": [

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import App from "./App";
 


### PR DESCRIPTION
Add the following:

Invoke linter, formatter and TypeScript checker with

```
# in /ui directory
npm run lint
```

This will invoke `tsc --noEmit && prettier --check . && eslint . --ext .ts,.tsx`

- `tsc --noEmit`: use TypeScript compiler to compile your code but do not output any compiled JavaScript codes since we only need the compiler to check typing for us.
- `prettier --check .`: use Prettier to check our code format
- `eslint . --ext .ts,.tsx`: Use ESLint to lint `*.ts` and `*.tsx` files